### PR TITLE
convert time millis -> time.Time before send

### DIFF
--- a/backend-build.Dockerfile
+++ b/backend-build.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine as plugin
+FROM golang:1.17-alpine as plugin
 
 RUN apk add build-base
 


### PR DESCRIPTION
It creates `DataFrame` with correct `type` field. Now it was sent as `number` while `time.Time` is translated into `time` for javascript so grafana displays it as formatted time by default.

<img width="402" alt="image" src="https://user-images.githubusercontent.com/8106010/164290491-133bdd6d-f251-4c6b-bde9-05ec07a47351.png">
<img width="568" alt="image" src="https://user-images.githubusercontent.com/8106010/164290559-108a589e-9261-4a8c-86f5-10f66657d27d.png">
